### PR TITLE
Add Path::Map to the ecosystem

### DIFF
--- a/META.list
+++ b/META.list
@@ -642,3 +642,4 @@ https://raw.githubusercontent.com/zoffixznet/perl6-Acme-Anguish/master/META6.jso
 https://raw.githubusercontent.com/jonathanstowe/Device-Velleman-K8055/master/META6.json
 https://raw.githubusercontent.com/araraloren/Getopt-Kinoko/master/META6.json
 https://raw.githubusercontent.com/zoffixznet/perl6-Test-When/master/META.info
+https://raw.githubusercontent.com/fjwhittle/p6-Path-Map/master/META.info


### PR DESCRIPTION
Port of Path::Map from Perl5 with extended functionality.

See https://github.com/fjwhittle/p6-Path-Map
